### PR TITLE
Sync frontend with backend contract changes

### DIFF
--- a/.claude/skills/artistic/SKILL.md
+++ b/.claude/skills/artistic/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: artistic
+description: High-contrast, expressive style with creative typography and bold color choices for visually striking interfaces.
+license: MIT
+metadata:
+  author: typeui.sh
+---
+
+<!-- TYPEUI_SH_MANAGED_START -->
+# Artistic Design System Skill (Universal)
+
+## Mission
+You are an expert design-system guideline author for Artistic.
+Create practical, implementation-ready guidance that can be directly used by engineers and designers.
+
+## Brand
+
+
+## Style Foundations
+- Visual style: high-contrast, artistic
+- Typography scale: 12/14/16/18/24/30/36 | Fonts: primary=Limelight, display=Limelight, mono=JetBrains Mono | weights=100, 200, 300, 400, 500, 600, 700, 800, 900
+- Color palette: primary, neutral, success, warning, danger | Tokens: primary=#3B82F6, secondary=#8B5CF6, success=#16A34A, warning=#D97706, danger=#DC2626, surface=#FFFFFF, text=#111827
+- Spacing scale: 4/8/12/16/24/32
+
+
+## Accessibility
+WCAG 2.2 AA, keyboard-first interactions, visible focus states, semantic HTML before ARIA, screen-reader tested labels, reduced-motion support, 44px+ touch targets, high-contrast support
+
+## Writing Tone
+concise, confident, professional, action-oriented
+
+## Rules: Do
+- prefer semantic tokens over raw values
+- preserve visual hierarchy
+- keep interaction states explicit
+- design for empty/loading/error states
+- ensure responsive behavior by default
+- document accessibility rationale
+
+## Rules: Don't
+- avoid low contrast text
+- avoid inconsistent spacing rhythm
+- avoid decorative motion without purpose
+- avoid ambiguous labels
+- avoid mixing multiple visual metaphors
+- avoid inaccessible hit areas
+
+## Expected Behavior
+- Follow the foundations first, then component consistency.
+- When uncertain, prioritize accessibility and clarity over novelty.
+- Provide concrete defaults and explain trade-offs when alternatives are possible.
+- Keep guidance opinionated, concise, and implementation-focused.
+
+## Guideline Authoring Workflow
+1. Restate the design intent in one sentence before proposing rules.
+2. Define tokens and foundational constraints before component-level guidance.
+3. Specify component anatomy, states, variants, and interaction behavior.
+4. Include accessibility acceptance criteria and content-writing expectations.
+5. Add anti-patterns and migration notes for existing inconsistent UI.
+6. End with a QA checklist that can be executed in code review.
+
+## Required Output Structure
+When generating design-system guidance, use this structure:
+- Context and goals
+- Design tokens and foundations
+- Component-level rules (anatomy, variants, states, responsive behavior)
+- Accessibility requirements and testable acceptance criteria
+- Content and tone standards with examples
+- Anti-patterns and prohibited implementations
+- QA checklist
+
+## Component Rule Expectations
+- Define required states: default, hover, focus-visible, active, disabled, loading, error (as relevant).
+- Describe interaction behavior for keyboard, pointer, and touch.
+- State spacing, typography, and color-token usage explicitly.
+- Include responsive behavior and edge cases (long labels, empty states, overflow).
+
+## Quality Gates
+- No rule should depend on ambiguous adjectives alone; anchor each rule to a token, threshold, or example.
+- Every accessibility statement must be testable in implementation.
+- Prefer system consistency over one-off local optimizations.
+- Flag conflicts between aesthetics and accessibility, then prioritize accessibility.
+
+## Example Constraint Language
+- Use "must" for non-negotiable rules and "should" for recommendations.
+- Pair every do-rule with at least one concrete don't-example.
+- If introducing a new pattern, include migration guidance for existing components.
+
+<!-- TYPEUI_SH_MANAGED_END -->

--- a/.claude/skills/bento/SKILL.md
+++ b/.claude/skills/bento/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: bento
+description: Modular grid layout with card-like blocks, clear hierarchy, soft spacing, and subtle visual contrast for organized, scannable interfaces.
+license: MIT
+metadata:
+  author: typeui.sh
+---
+
+<!-- TYPEUI_SH_MANAGED_START -->
+# Bento Design System Skill (Universal)
+
+## Mission
+You are an expert design-system guideline author for Bento.
+Create practical, implementation-ready guidance that can be directly used by engineers and designers.
+
+## Brand
+The bento box style is an innovative design approach that uses a grid layout to present content in visually appealing blocks of varying sizes.
+
+## Style Foundations
+- Visual style: modern, clean
+- Typography scale: 12/14/16/20/24/32 | Fonts: primary=Inter, display=Inter, mono=JetBrains Mono | weights=100, 200, 300, 400, 500, 600, 700, 800, 900
+- Color palette: primary, neutral, success, warning, danger | Tokens: primary=#FAD4C0, secondary=#80A1C1, success=#16A34A, warning=#D97706, danger=#DC2626, surface=#FFF5E6, text=#111827
+- Spacing scale: 4/8/12/16/24/32
+
+
+## Accessibility
+WCAG 2.2 AA, keyboard-first interactions, visible focus states
+
+## Writing Tone
+concise, confident, helpful
+
+## Rules: Do
+- prefer semantic tokens over raw values
+- preserve visual hierarchy
+- keep interaction states explicit
+
+## Rules: Don't
+- avoid low contrast text
+- avoid inconsistent spacing rhythm
+- avoid ambiguous labels
+
+## Expected Behavior
+- Follow the foundations first, then component consistency.
+- When uncertain, prioritize accessibility and clarity over novelty.
+- Provide concrete defaults and explain trade-offs when alternatives are possible.
+- Keep guidance opinionated, concise, and implementation-focused.
+
+## Guideline Authoring Workflow
+1. Restate the design intent in one sentence before proposing rules.
+2. Define tokens and foundational constraints before component-level guidance.
+3. Specify component anatomy, states, variants, and interaction behavior.
+4. Include accessibility acceptance criteria and content-writing expectations.
+5. Add anti-patterns and migration notes for existing inconsistent UI.
+6. End with a QA checklist that can be executed in code review.
+
+## Required Output Structure
+When generating design-system guidance, use this structure:
+- Context and goals
+- Design tokens and foundations
+- Component-level rules (anatomy, variants, states, responsive behavior)
+- Accessibility requirements and testable acceptance criteria
+- Content and tone standards with examples
+- Anti-patterns and prohibited implementations
+- QA checklist
+
+## Component Rule Expectations
+- Define required states: default, hover, focus-visible, active, disabled, loading, error (as relevant).
+- Describe interaction behavior for keyboard, pointer, and touch.
+- State spacing, typography, and color-token usage explicitly.
+- Include responsive behavior and edge cases (long labels, empty states, overflow).
+
+## Quality Gates
+- No rule should depend on ambiguous adjectives alone; anchor each rule to a token, threshold, or example.
+- Every accessibility statement must be testable in implementation.
+- Prefer system consistency over one-off local optimizations.
+- Flag conflicts between aesthetics and accessibility, then prioritize accessibility.
+
+## Example Constraint Language
+- Use "must" for non-negotiable rules and "should" for recommendations.
+- Pair every do-rule with at least one concrete don't-example.
+- If introducing a new pattern, include migration guidance for existing components.
+
+<!-- TYPEUI_SH_MANAGED_END -->

--- a/.claude/skills/premium/SKILL.md
+++ b/.claude/skills/premium/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: premium
+description: Apple-inspired premium aesthetic with precise spacing, modern typography, and a refined, polished visual language.
+license: MIT
+metadata:
+  author: typeui.sh
+---
+
+<!-- TYPEUI_SH_MANAGED_START -->
+# Premium Design System Skill (Universal)
+
+## Mission
+You are an expert design-system guideline author for premium.
+Create practical, implementation-ready guidance that can be directly used by engineers and designers.
+
+## Brand
+Apple design style
+
+## Style Foundations
+- Visual style: modern
+- Typography scale: 12/14/16/18/24/30/36 | Fonts: primary=Inter, display=Inter, mono=JetBrains Mono | weights=100, 200, 300, 400, 500, 600, 700, 800, 900
+- Color palette: primary, neutral, success, warning, danger | Tokens: primary=#3B82F6, secondary=#8B5CF6, success=#16A34A, warning=#D97706, danger=#DC2626, surface=#FFFFFF, text=#111827
+- Spacing scale: 4/8/12/16/24/32
+
+
+## Accessibility
+WCAG 2.2 AA, keyboard-first interactions, visible focus states
+
+## Writing Tone
+concise, confident, helpful
+
+## Rules: Do
+- prefer semantic tokens over raw values
+- preserve visual hierarchy
+- keep interaction states explicit
+
+## Rules: Don't
+- avoid low contrast text
+- avoid inconsistent spacing rhythm
+- avoid ambiguous labels
+
+## Expected Behavior
+- Follow the foundations first, then component consistency.
+- When uncertain, prioritize accessibility and clarity over novelty.
+- Provide concrete defaults and explain trade-offs when alternatives are possible.
+- Keep guidance opinionated, concise, and implementation-focused.
+
+## Guideline Authoring Workflow
+1. Restate the design intent in one sentence before proposing rules.
+2. Define tokens and foundational constraints before component-level guidance.
+3. Specify component anatomy, states, variants, and interaction behavior.
+4. Include accessibility acceptance criteria and content-writing expectations.
+5. Add anti-patterns and migration notes for existing inconsistent UI.
+6. End with a QA checklist that can be executed in code review.
+
+## Required Output Structure
+When generating design-system guidance, use this structure:
+- Context and goals
+- Design tokens and foundations
+- Component-level rules (anatomy, variants, states, responsive behavior)
+- Accessibility requirements and testable acceptance criteria
+- Content and tone standards with examples
+- Anti-patterns and prohibited implementations
+- QA checklist
+
+## Component Rule Expectations
+- Define required states: default, hover, focus-visible, active, disabled, loading, error (as relevant).
+- Describe interaction behavior for keyboard, pointer, and touch.
+- State spacing, typography, and color-token usage explicitly.
+- Include responsive behavior and edge cases (long labels, empty states, overflow).
+
+## Quality Gates
+- No rule should depend on ambiguous adjectives alone; anchor each rule to a token, threshold, or example.
+- Every accessibility statement must be testable in implementation.
+- Prefer system consistency over one-off local optimizations.
+- Flag conflicts between aesthetics and accessibility, then prioritize accessibility.
+
+## Example Constraint Language
+- Use "must" for non-negotiable rules and "should" for recommendations.
+- Pair every do-rule with at least one concrete don't-example.
+- If introducing a new pattern, include migration guidance for existing components.
+
+<!-- TYPEUI_SH_MANAGED_END -->

--- a/src/components/dashboard/ProjectCard.tsx
+++ b/src/components/dashboard/ProjectCard.tsx
@@ -45,7 +45,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onDelete }) =
   const navigate = useNavigate();
 
   const statusBadge = getStatusBadgeProps(project.overallStatus);
-  const relativeTime = formatRelativeTime(project.lastUpdatedAt);
+  const relativeTime = formatRelativeTime(project.updatedAt);
 
   return (
     <GlassCard className="hover-scale-sm p-5">
@@ -53,7 +53,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onDelete }) =
         <div className="flex-between gap-3">
           <div className="flex-1 min-w-0">
             <h3 className="text-title text-base line-clamp-1">
-              {project.workingTitle}
+              {project.title}
             </h3>
             {project.thumbnailHint && (
               <p className="text-caption line-clamp-1 mt-0.5">
@@ -63,13 +63,13 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onDelete }) =
           </div>
           <button
             type="button"
-            aria-label={`Delete project ${project.workingTitle}`}
+            aria-label={`Delete project ${project.title}`}
             className={cn(
               "shrink-0 rounded-lg p-1.5 text-muted-foreground transition-colors duration-200",
               "hover:text-destructive hover:bg-destructive/10",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive",
             )}
-            onClick={() => onDelete(project.id, project.workingTitle)}
+            onClick={() => onDelete(project.id, project.title)}
           >
             <Trash2 className="size-4" />
           </button>

--- a/src/components/packaging/ShortsScriptCard.tsx
+++ b/src/components/packaging/ShortsScriptCard.tsx
@@ -7,26 +7,17 @@ import {
   Check,
   Film,
   Clock,
-  Plus,
-  Trash2,
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
 import { toastError, toastSuccess } from "@/utils/toast";
 import GradientSkeleton from "./GradientSkeleton";
-import {
-  IShortsScript,
-  MAX_SHORTS_SCRIPTS,
-} from "@/types/feature/packaging";
+import { IShortsOutput } from "@/types/feature/packaging";
 import { FeedbackButtons } from "@/components/research/FeedbackButtons";
 
 interface ShortsScriptCardProps {
-  scripts: IShortsScript[];
-  isAddingNew: boolean;
-  canAddMore: boolean;
-  onAddNew: () => void;
-  onRegenerate: (scriptId: string) => void;
-  onDelete: (scriptId: string) => void;
+  shortsScript: IShortsOutput;
+  onRegenerate: () => void;
   feedback?: "like" | "dislike" | null;
   onFeedback?: (feedback: "like" | "dislike" | null) => void;
 }
@@ -58,28 +49,20 @@ const segmentStyles = {
   },
 };
 
-interface SingleScriptProps {
-  script: IShortsScript;
-  index: number;
-  totalScripts: number;
-  onRegenerate: () => void;
-  onDelete: () => void;
-}
-
-const SingleScript = ({
-  script,
-  index,
-  totalScripts,
+const ShortsScriptCard = ({
+  shortsScript,
   onRegenerate,
-  onDelete,
-}: SingleScriptProps) => {
-
+  feedback,
+  onFeedback,
+}: ShortsScriptCardProps) => {
   const [copied, setCopied] = useState(false);
   const [isExpanded, setIsExpanded] = useState(true);
 
+  const { segments, totalDuration, isLoading, error } = shortsScript;
+
   const handleCopyAll = async () => {
     try {
-      const fullScript = script.segments
+      const fullScript = segments
         .map((seg) => `[${seg.startTime} - ${seg.endTime}]\n${seg.content}`)
         .join("\n\n");
       await navigator.clipboard.writeText(fullScript);
@@ -91,219 +74,7 @@ const SingleScript = ({
     }
   };
 
-  const getTotalDuration = () => {
-    if (script.segments.length === 0) return "0:00";
-    const lastSegment = script.segments[script.segments.length - 1];
-    return lastSegment.endTime;
-  };
-
-  return (
-    <div
-      className={cn(
-        "rounded-xl border border-white/10 bg-white/5",
-        "transition-all duration-300",
-        "hover:border-white/20",
-      )}
-    >
-      {/* Script Header */}
-      <button
-        type="button"
-        aria-expanded={isExpanded}
-        className="flex w-full items-center justify-between p-4 text-left"
-        onClick={() => setIsExpanded(!isExpanded)}
-      >
-        <div className="flex items-center gap-3">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-pink-500/20 to-violet-500/20 border border-pink-500/30">
-            <span className="text-sm font-bold text-pink-400">{index + 1}</span>
-          </div>
-          <div>
-            <h4 className="text-sm font-medium text-foreground">
-              Script Variation {index + 1}
-            </h4>
-            {!script.isLoading && script.segments.length > 0 && (
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Clock className="h-3 w-3" />
-                <span>{getTotalDuration()}</span>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="flex items-center gap-1">
-          {!script.isLoading && script.segments.length > 0 && (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Copy script"
-                className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCopyAll();
-                }}
-              >
-                {copied ? (
-                  <Check className="h-3.5 w-3.5 text-emerald-400" />
-                ) : (
-                  <Copy className="h-3.5 w-3.5" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Regenerate script"
-                className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onRegenerate();
-                }}
-                disabled={script.isLoading}
-              >
-                <RefreshCw className={cn("h-3.5 w-3.5", script.isLoading && "motion-safe:animate-spin")} />
-              </Button>
-            </>
-          )}
-          {totalScripts > 1 && (
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="Delete script variation"
-              className="h-7 w-7 text-muted-foreground hover:text-destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label={isExpanded ? "Collapse script" : "Expand script"}
-            className="h-7 w-7 text-muted-foreground"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsExpanded(!isExpanded);
-            }}
-          >
-            {isExpanded ? (
-              <ChevronUp className="h-4 w-4" />
-            ) : (
-              <ChevronDown className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-      </button>
-
-      {/* Script Content */}
-      {isExpanded && (
-        <div className="border-t border-white/10 p-4">
-          {script.isLoading ? (
-            <div className="space-y-4">
-              {[1, 2, 3, 4].map((i) => (
-                <div key={i} className="flex gap-4">
-                  <div className="w-16 shrink-0">
-                    <GradientSkeleton lines={1} className="h-4" />
-                  </div>
-                  <div className="flex-1">
-                    <GradientSkeleton lines={2} />
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : script.error ? (
-            <div className="rounded-lg bg-destructive/10 border border-destructive/30 p-3 text-sm text-destructive">
-              {script.error}
-            </div>
-          ) : script.segments.length > 0 ? (
-            <div className="relative space-y-0">
-              {/* Timeline line */}
-              <div className="absolute left-[44px] top-0 bottom-0 w-px bg-gradient-to-b from-primary/50 via-pink-500/50 to-emerald-500/50" />
-
-              {script.segments.map((segment, segIndex) => {
-                const style = segmentStyles[segment.type];
-                return (
-                  <div
-                    key={segIndex}
-                    className="group relative flex items-start gap-3 py-2.5"
-                  >
-                    {/* Timestamp */}
-                    <div className="w-10 shrink-0 pt-0.5 text-right">
-                      <span className="text-[10px] font-mono font-medium text-muted-foreground">
-                        {segment.startTime}
-                      </span>
-                    </div>
-
-                    {/* Timeline dot */}
-                    <div className="relative flex h-4 w-4 shrink-0 items-center justify-center">
-                      <div
-                        className={cn(
-                          "h-2.5 w-2.5 rounded-full",
-                          "ring-2 ring-background",
-                          style.bg,
-                          "border",
-                          style.border,
-                          "transition-transform group-hover:scale-125",
-                        )}
-                      />
-                    </div>
-
-                    {/* Content */}
-                    <div
-                      className={cn(
-                        "flex-1 rounded-lg p-2.5",
-                        style.bg,
-                        "border",
-                        style.border,
-                        "transition-all group-hover:translate-x-0.5",
-                      )}
-                    >
-                      <div className="mb-1.5 flex items-center justify-between">
-                        <span
-                          className={cn(
-                            "inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider",
-                            style.badge,
-                          )}
-                        >
-                          {segment.type}
-                        </span>
-                        <span className="text-[9px] text-muted-foreground">
-                          {segment.startTime} - {segment.endTime}
-                        </span>
-                      </div>
-                      <p className="text-xs leading-relaxed text-foreground/80">
-                        {segment.content}
-                      </p>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-6 text-center">
-              <Film className="mb-2 h-6 w-6 text-muted-foreground" />
-              <p className="text-xs text-muted-foreground">
-                Click regenerate to generate this script
-              </p>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
-const ShortsScriptCard = ({
-  scripts,
-  isAddingNew,
-  canAddMore,
-  onAddNew,
-  onRegenerate,
-  onDelete,
-  feedback,
-  onFeedback,
-}: ShortsScriptCardProps) => {
+  const displayDuration = totalDuration ?? (segments.length > 0 ? segments[segments.length - 1].endTime : "0:00");
 
   return (
     <div
@@ -325,11 +96,14 @@ const ShortsScriptCard = ({
             </div>
             <div>
               <h3 className="font-semibold tracking-tight text-foreground">
-                YT Shorts Scripts
+                YT Shorts Script
               </h3>
-              <p className="text-xs text-muted-foreground">
-                {scripts.length} of {MAX_SHORTS_SCRIPTS} variations
-              </p>
+              {!isLoading && segments.length > 0 && (
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Clock className="h-3 w-3" />
+                  <span>{displayDuration}</span>
+                </div>
+              )}
             </div>
           </div>
 
@@ -341,48 +115,141 @@ const ShortsScriptCard = ({
                 onFeedback={(_id, fb) => onFeedback(fb)}
               />
             )}
-            {canAddMore && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-dashed border-white/20 text-muted-foreground hover:text-foreground hover:border-white/30 hover:bg-white/5"
-                onClick={onAddNew}
-                disabled={isAddingNew}
-              >
-                {isAddingNew ? (
-                  <RefreshCw className="mr-1.5 h-3.5 w-3.5 motion-safe:animate-spin" />
-                ) : (
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                )}
-                Add Variation
-              </Button>
+            {!isLoading && segments.length > 0 && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Copy script"
+                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                  onClick={handleCopyAll}
+                >
+                  {copied ? (
+                    <Check className="h-3.5 w-3.5 text-emerald-400" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </Button>
+              </>
             )}
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Regenerate script"
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              onClick={onRegenerate}
+              disabled={isLoading}
+            >
+              <RefreshCw className={cn("h-3.5 w-3.5", isLoading && "motion-safe:animate-spin")} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={isExpanded ? "Collapse script" : "Expand script"}
+              className="h-7 w-7 text-muted-foreground"
+              onClick={() => setIsExpanded(!isExpanded)}
+            >
+              {isExpanded ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </Button>
           </div>
         </div>
 
-        {/* Scripts List */}
-        {scripts.length > 0 ? (
-          <div className="space-y-4">
-            {scripts.map((script, index) => (
-              <SingleScript
-                key={script.id}
-                script={script}
-                index={index}
-                totalScripts={scripts.length}
-                onRegenerate={() => onRegenerate(script.id)}
-                onDelete={() => onDelete(script.id)}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-white/5 border border-white/10">
-              <Film className="h-8 w-8 text-muted-foreground" />
-            </div>
-            <p className="text-sm text-muted-foreground mb-1">No shorts scripts yet</p>
-            <p className="text-xs text-muted-foreground">
-              Generate your first script using the button above
-            </p>
+        {/* Script Content */}
+        {isExpanded && (
+          <div className="border-t border-white/10 pt-4">
+            {isLoading ? (
+              <div className="space-y-4">
+                {[1, 2, 3, 4].map((i) => (
+                  <div key={i} className="flex gap-4">
+                    <div className="w-16 shrink-0">
+                      <GradientSkeleton lines={1} className="h-4" />
+                    </div>
+                    <div className="flex-1">
+                      <GradientSkeleton lines={2} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : error ? (
+              <div className="rounded-lg bg-destructive/10 border border-destructive/30 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            ) : segments.length > 0 ? (
+              <div className="relative space-y-0">
+                {/* Timeline line */}
+                <div className="absolute left-[44px] top-0 bottom-0 w-px bg-gradient-to-b from-primary/50 via-pink-500/50 to-emerald-500/50" />
+
+                {segments.map((segment, segIndex) => {
+                  const style = segmentStyles[segment.type];
+                  return (
+                    <div
+                      key={segIndex}
+                      className="group relative flex items-start gap-3 py-2.5"
+                    >
+                      {/* Timestamp */}
+                      <div className="w-10 shrink-0 pt-0.5 text-right">
+                        <span className="text-[10px] font-mono font-medium text-muted-foreground">
+                          {segment.startTime}
+                        </span>
+                      </div>
+
+                      {/* Timeline dot */}
+                      <div className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+                        <div
+                          className={cn(
+                            "h-2.5 w-2.5 rounded-full",
+                            "ring-2 ring-background",
+                            style.bg,
+                            "border",
+                            style.border,
+                            "transition-transform group-hover:scale-125",
+                          )}
+                        />
+                      </div>
+
+                      {/* Content */}
+                      <div
+                        className={cn(
+                          "flex-1 rounded-lg p-2.5",
+                          style.bg,
+                          "border",
+                          style.border,
+                          "transition-all group-hover:translate-x-0.5",
+                        )}
+                      >
+                        <div className="mb-1.5 flex items-center justify-between">
+                          <span
+                            className={cn(
+                              "inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider",
+                              style.badge,
+                            )}
+                          >
+                            {segment.type}
+                          </span>
+                          <span className="text-[9px] text-muted-foreground">
+                            {segment.startTime} - {segment.endTime}
+                          </span>
+                        </div>
+                        <p className="text-xs leading-relaxed text-foreground/80">
+                          {segment.content}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-6 text-center">
+                <Film className="mb-2 h-6 w-6 text-muted-foreground" />
+                <p className="text-xs text-muted-foreground">
+                  Click regenerate to generate the shorts script
+                </p>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/project/ProjectHeader.tsx
+++ b/src/components/project/ProjectHeader.tsx
@@ -60,23 +60,23 @@ export const ProjectHeader: React.FC = () => {
   const statusBadge = getStatusBadgeProps(currentProject.overallStatus);
 
   function handleTitleClick() {
-    setEditValue(currentProject.workingTitle);
+    setEditValue(currentProject.title);
     setIsEditing(true);
   }
 
   async function handleTitleSave() {
     const trimmed = editValue.trim();
-    if (!trimmed || trimmed === currentProject.workingTitle) {
+    if (!trimmed || trimmed === currentProject.title) {
       setIsEditing(false);
       return;
     }
     try {
       await dispatch(
-        updateWorkingTitle({ projectId: currentProject.id, workingTitle: trimmed })
+        updateWorkingTitle({ projectId: currentProject.id, title: trimmed })
       ).unwrap();
       setIsEditing(false);
     } catch {
-      setEditValue(currentProject.workingTitle);
+      setEditValue(currentProject.title);
       toastError("Failed to update title");
       setIsEditing(false);
     }
@@ -110,7 +110,7 @@ export const ProjectHeader: React.FC = () => {
       <div className="flex items-center gap-2 min-w-0 flex-1">
         {isEditing ? (
           <>
-            <h1 className="sr-only">{editValue || currentProject.workingTitle}</h1>
+            <h1 className="sr-only">{editValue || currentProject.title}</h1>
             <input
               ref={inputRef}
               type="text"
@@ -134,11 +134,11 @@ export const ProjectHeader: React.FC = () => {
         ) : (
           <>
             <h1 className="text-foreground font-semibold text-lg leading-tight truncate min-w-0">
-              {project.workingTitle}
+              {project.title}
             </h1>
             <button
               type="button"
-              aria-label={`Edit working title: ${project.workingTitle}`}
+              aria-label={`Edit working title: ${project.title}`}
               onClick={handleTitleClick}
               className={cn(
                 "shrink-0 text-muted-foreground opacity-0 hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-200",

--- a/src/components/shared/ProtectedRoute/index.tsx
+++ b/src/components/shared/ProtectedRoute/index.tsx
@@ -1,5 +1,4 @@
 import { Outlet, Navigate, useLocation } from "react-router-dom";
-import { isUserLoggedIn } from "@/utils";
 import RootLoader from "@/components/shared/Loader";
 import { useAppDispatch, useAppSelector } from "@/hooks/useRedux";
 import { currentUser, userLoading } from "@/utils/feature/user/user.slice";
@@ -17,8 +16,6 @@ const ProtectedLayout = () => {
   const user = useAppSelector(currentUser);
   const loading = useAppSelector(userLoading);
   const location = useLocation();
-
-  const isLoggedIn = isUserLoggedIn();
 
   const titles = useAppSelector(selectTitlesData);
   const scripts = useAppSelector(selectScriptsData);
@@ -52,11 +49,20 @@ const ProtectedLayout = () => {
     };
   }, []);
 
-  if (loading) {
+  // Only block the whole subtree during the INITIAL auth resolution (no user yet).
+  // A background refetch of an already-loaded user must not unmount children —
+  // otherwise a child that dispatches getUser on mount (e.g. Dashboard) loops:
+  // pending → loading → unmount → fulfilled → remount → dispatch → pending …
+  if (loading && !user) {
     return <RootLoader />;
-  } else if (user && !user?.isOnboardingCompleted && location.pathname !== "/app/onboarding") {
+  } else if (
+    !HIDE_OLD_FLOW &&
+    user &&
+    !user?.isOnboardingCompleted &&
+    location.pathname !== "/app/onboarding"
+  ) {
     return <Navigate to="/app/onboarding" />;
-  } else if (!isLoggedIn) {
+  } else if (!user) {
     return <Navigate to={`/login`} replace state={{ from: location }} />;
   }
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -27,6 +27,7 @@ export const useAuthenticate = () => {
           );
         } else dispatch(getUser());
       } else {
+        localStorage.removeItem(LOGGED_IN);
         dispatch(setUser(null));
       }
     });

--- a/src/hooks/useScriptStream.tsx
+++ b/src/hooks/useScriptStream.tsx
@@ -3,16 +3,12 @@ import { useAppDispatch } from "@/hooks/useRedux";
 import { scriptService } from "@/service/script";
 import { markDone, resetState } from "@/utils/feature/scripts/script.slice";
 import {
-  getScriptById,
-} from "@/utils/feature/scripts/script.thunk";
-import {
   getProject,
   startStep,
 } from "@/utils/feature/videoProject/videoProject.thunk";
 import { SCRIPT_GENERATION_DELAY_MS } from "@/constants/app";
 
 interface UseScriptStreamOptions {
-  scriptId: string;
   projectId: string;
 }
 
@@ -33,7 +29,6 @@ interface UseScriptStreamReturn {
  * Token is fetched manually via auth.currentUser?.getIdToken() inside the service.
  */
 export const useScriptStream = ({
-  scriptId,
   projectId,
 }: UseScriptStreamOptions): UseScriptStreamReturn => {
   const dispatch = useAppDispatch();
@@ -49,7 +44,7 @@ export const useScriptStream = ({
   const mountedRef = useRef(true);
 
   const startStreaming = useCallback(() => {
-    if (!scriptId || !projectId) return;
+    if (!projectId) return;
 
     // Guard against duplicate streams
     if (isStreamingRef.current) return;
@@ -88,11 +83,11 @@ export const useScriptStream = ({
         if (!mountedRef.current) return;
         dispatch(markDone());
         // Backend auto-started, auto-linked, auto-completed the script step.
-        // Re-fetch project to get updated pipeline state, then load the script.
+        // Re-fetch the project to pick up the newly-set scriptId; the page then
+        // loads the script once project.scriptId is available.
         timeoutRef.current = setTimeout(() => {
           if (!mountedRef.current) return;
           dispatch(getProject(projectId));
-          dispatch(getScriptById(scriptId));
           setIsStreaming(false);
           isStreamingRef.current = false;
         }, SCRIPT_GENERATION_DELAY_MS);
@@ -100,7 +95,7 @@ export const useScriptStream = ({
 
       try {
         const evtSource = await scriptService.startStreamingScripts(
-          scriptId,
+          projectId,
           onChunk,
           onDone,
           onError
@@ -112,7 +107,7 @@ export const useScriptStream = ({
     };
 
     initStream();
-  }, [scriptId, projectId, dispatch]);
+  }, [projectId, dispatch]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,19 +1,16 @@
-import { useEffect } from "react";
 import { DashboardCard, Greetings, ProjectList } from "@/components/dashboard";
 import { DASHBOARD_CARD } from "@/constants/dashboard";
 import Header from "@/components/shared/header";
-import { useAppDispatch, useAppSelector } from "@/hooks/useRedux";
+import { useAppSelector } from "@/hooks/useRedux";
 import { currentUser } from "@/utils/feature/user/user.slice";
-import { getUser } from "@/utils/feature/user/user.thunk";
 
 const Dashboard = () => {
-  const dispatch = useAppDispatch();
+  // The user/profile is loaded once by the Firebase auth listener (useAuth).
+  // Do NOT refetch it here: getUser's pending flips user.isLoading, which the
+  // route guard (ProtectedLayout) reacts to — refetching on mount creates a
+  // mount → pending → guard-loader → unmount → settle → remount loop.
   const { stats = { topics: 0, scripts: 0, credits: 0 } } =
     useAppSelector(currentUser) ?? {};
-
-  useEffect(() => {
-    dispatch(getUser());
-  }, [dispatch]);
 
   return (
     <div className="md:w-[90%] mx-auto pb-20">

--- a/src/pages/Packaging/index.tsx
+++ b/src/pages/Packaging/index.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/packaging";
 import {
   selectPackaging,
-  selectCanAddMoreShorts,
   selectHasContent,
   setScript,
   updateTitleVariation,
@@ -20,7 +19,6 @@ import {
   setSelectedThumbnail,
   updateHook,
   deleteHook,
-  deleteShortsScript,
   resetPackaging,
 } from "@/utils/feature/packaging/packaging.slice";
 import {
@@ -28,7 +26,6 @@ import {
   generateDescription,
   generateThumbnail,
   generateHooks,
-  addNewShortsScript,
   regenerateShortsScript,
   generateAllPackaging,
   savePackaging,
@@ -58,18 +55,14 @@ const PackagingPage = () => {
     isSaving,
     isGeneratingAll,
   } = useAppSelector(selectPackaging);
-  const canAddMoreShorts = useAppSelector(selectCanAddMoreShorts);
   const hasContent = useAppSelector(selectHasContent);
-
-  const isAnyShortsLoading = shortsScript.scripts.some((s) => s.isLoading);
 
   const isAnyLoading =
     titles.isLoading ||
     description.isLoading ||
     thumbnails.isLoading ||
     hooks.isLoading ||
-    isAnyShortsLoading ||
-    shortsScript.isAddingNew;
+    shortsScript.isLoading;
 
   const handleGenerateAll = () => {
     if (!script.trim()) {
@@ -95,21 +88,12 @@ const PackagingPage = () => {
     toastInfo("All content has been cleared");
   };
 
-  const handleAddNewShorts = () => {
+  const handleRegenerateShorts = () => {
     if (!script.trim()) {
       toastError("Please enter a podcast script first");
       return;
     }
-    dispatch(addNewShortsScript());
-  };
-
-  const handleRegenerateShorts = (scriptId: string) => {
-    dispatch(regenerateShortsScript(scriptId));
-  };
-
-  const handleDeleteShorts = (scriptId: string) => {
-    dispatch(deleteShortsScript(scriptId));
-    toastInfo("Script variation removed");
+    dispatch(regenerateShortsScript());
   };
 
   return (
@@ -251,14 +235,10 @@ const PackagingPage = () => {
             onDeleteHook={(index) => dispatch(deleteHook(index))}
           />
 
-          {/* Shorts Scripts - Multiple variations */}
+          {/* Shorts Script */}
           <ShortsScriptCard
-            scripts={shortsScript.scripts}
-            isAddingNew={shortsScript.isAddingNew}
-            canAddMore={canAddMoreShorts}
-            onAddNew={handleAddNewShorts}
+            shortsScript={shortsScript}
             onRegenerate={handleRegenerateShorts}
-            onDelete={handleDeleteShorts}
           />
         </section>
 

--- a/src/pages/ProjectHooks/index.tsx
+++ b/src/pages/ProjectHooks/index.tsx
@@ -106,9 +106,7 @@ const ProjectHooksPage = () => {
 
   const handleSelect = async (hookIndex: number) => {
     if (!hooksId || !projectId || isSelecting) return;
-    const result = await dispatch(
-      selectHook({ hooksId, hookIndex, videoProjectId: projectId })
-    );
+    const result = await dispatch(selectHook({ hooksId, hookIndex }));
     if (selectHook.fulfilled.match(result)) {
       await dispatch(getProject(projectId));
       navigate(`/app/project/${projectId}/packaging`);

--- a/src/pages/ProjectHooks/index.tsx
+++ b/src/pages/ProjectHooks/index.tsx
@@ -78,11 +78,11 @@ const ProjectHooksPage = () => {
 
   // Effect 2 — Load script if not already loaded (needed for generate/regenerate)
   useEffect(() => {
-    const scriptId = project?.topicId;
+    const scriptId = project?.scriptId;
     if (scriptId && !currentScript) {
       dispatch(getScriptById(scriptId));
     }
-  }, [project?.topicId, currentScript, dispatch]);
+  }, [project?.scriptId, currentScript, dispatch]);
 
   // Effect 3 — Cleanup on unmount (do NOT clear batch — cache it per 6f)
   useEffect(() => {

--- a/src/pages/ProjectPackaging/index.tsx
+++ b/src/pages/ProjectPackaging/index.tsx
@@ -104,11 +104,11 @@ const ProjectPackagingPage = () => {
 
   // Effect 1 — Load script if not cached
   useEffect(() => {
-    const scriptId = project?.topicId;
+    const scriptId = project?.scriptId;
     if (scriptId && !currentScript) {
       dispatch(getScriptById(scriptId));
     }
-  }, [project?.topicId, currentScript, dispatch]);
+  }, [project?.scriptId, currentScript, dispatch]);
 
   // Effect 2 — Load existing packaging if available
   useEffect(() => {

--- a/src/pages/ProjectPackaging/index.tsx
+++ b/src/pages/ProjectPackaging/index.tsx
@@ -360,7 +360,7 @@ const ProjectPackagingPage = () => {
       {/* Completion celebration */}
       {project.overallStatus === "completed" && (
         <CompletionCelebration
-          projectTitle={project.workingTitle}
+          projectTitle={project.title}
           onExport={handleExport}
           onBackToProjects={() => navigate("/app/dashboard")}
           isExporting={isExporting}

--- a/src/pages/ProjectPackaging/index.tsx
+++ b/src/pages/ProjectPackaging/index.tsx
@@ -25,7 +25,6 @@ import {
   selectDescription,
   selectThumbnails,
   selectShortsScripts,
-  selectCanAddMoreShorts,
   selectIsSaving,
   selectIsGeneratingAll,
   selectCurrentPackaging,
@@ -39,7 +38,6 @@ import {
   updateTitleVariation,
   updateDescription,
   setSelectedThumbnail,
-  deleteShortsScript,
   resetPackaging,
   clearErrors,
   setScript,
@@ -51,7 +49,6 @@ import {
   getPackaging,
   regenerateItem,
   exportPackaging,
-  addNewShortsScript,
   regenerateShortsScript,
   generateTitle,
   generateDescription,
@@ -85,7 +82,6 @@ const ProjectPackagingPage = () => {
   const description = useAppSelector(selectDescription);
   const thumbnails = useAppSelector(selectThumbnails);
   const shortsScript = useAppSelector(selectShortsScripts);
-  const canAddMoreShorts = useAppSelector(selectCanAddMoreShorts);
   const isSaving = useAppSelector(selectIsSaving);
   const isGeneratingAll = useAppSelector(selectIsGeneratingAll);
   const currentPackaging = useAppSelector(selectCurrentPackaging);
@@ -521,14 +517,12 @@ const ProjectPackagingPage = () => {
             />
           )}
           <ShortsScriptCard
-            scripts={shortsScript.scripts}
-            isAddingNew={shortsScript.isAddingNew}
-            canAddMore={canAddMoreShorts}
-            onAddNew={() => dispatch(addNewShortsScript())}
-            onRegenerate={(scriptId) =>
-              dispatch(regenerateShortsScript(scriptId))
+            shortsScript={shortsScript}
+            onRegenerate={
+              packagingId
+                ? () => handleRegenerateItem("shorts")
+                : () => dispatch(regenerateShortsScript())
             }
-            onDelete={(scriptId) => dispatch(deleteShortsScript(scriptId))}
             feedback={packagingId ? (itemFeedback.shorts ?? null) : undefined}
             onFeedback={packagingId ? (fb) => handleFeedback("shorts", fb) : undefined}
           />

--- a/src/pages/ProjectPackaging/index.tsx
+++ b/src/pages/ProjectPackaging/index.tsx
@@ -61,10 +61,6 @@ import {
 import { selectCurrentScript } from "@/utils/feature/scripts/script.slice";
 import { getScriptById } from "@/utils/feature/scripts/script.thunk";
 import {
-  selectHooksBatch,
-  selectSelectedHookIndex,
-} from "@/utils/feature/hooks/hooks.slice";
-import {
   TitlesCard,
   OutputCard,
   ThumbnailsCard,
@@ -99,17 +95,12 @@ const ProjectPackagingPage = () => {
   const error = useAppSelector(selectPackagingError);
   const hasContent = useAppSelector(selectHasContent);
   const currentScript = useAppSelector(selectCurrentScript);
-  const hooksBatch = useAppSelector(selectHooksBatch);
-  const selectedHookIndex = useAppSelector(selectSelectedHookIndex);
   const itemFeedback = useAppSelector(selectItemFeedback);
 
   const projectId = project?.id ?? "";
   const packagingId = currentPackaging?.id ?? project?.packagingId ?? "";
   const scriptText = currentScript?.script ?? "";
   const selectedTitle = titles.titles[titles.selectedIndex]?.title ?? "";
-  const hookIndex = selectedHookIndex ?? project?.selectedHookIndex;
-  const selectedHookText =
-    hookIndex != null ? (hooksBatch?.hooks?.[hookIndex] ?? "") : "";
 
   // Effect 1 — Load script if not cached
   useEffect(() => {
@@ -166,7 +157,7 @@ const ProjectPackagingPage = () => {
     await dispatch(
       generateAllPackagingForProject({
         script: scriptText,
-        selectedHook: selectedHookText || undefined,
+        videoProjectId: projectId,
       })
     );
     if (mountedRef.current) {
@@ -190,7 +181,6 @@ const ProjectPackagingPage = () => {
         item,
         script: scriptText,
         title: item !== "title" ? selectedTitle : undefined,
-        selectedHook: selectedHookText || undefined,
       })
     );
     if (regenerateItem.fulfilled.match(result)) {
@@ -232,7 +222,6 @@ const ProjectPackagingPage = () => {
           item,
           script: scriptText,
           title: item !== "title" ? selectedTitle : undefined,
-          selectedHook: selectedHookText || undefined,
         })
       );
       if (regenerateItem.rejected.match(result)) break;

--- a/src/pages/ProjectScript/index.tsx
+++ b/src/pages/ProjectScript/index.tsx
@@ -62,12 +62,12 @@ const ProjectScriptPage = () => {
 
   const [isEditMode, setIsEditMode] = useState(false);
 
-  const scriptId = project?.topicId ?? "";
+  const scriptId = project?.scriptId ?? "";
   const hasScript = !!project?.scriptId;
   const projectId = project?.id ?? "";
 
   const { streamContent, isStreaming, streamError, startStreaming, scrollSentinelRef } =
-    useScriptStream({ scriptId, projectId });
+    useScriptStream({ projectId });
 
   // Effect 1 — Load existing script when one is available
   useEffect(() => {

--- a/src/pages/Research/index.tsx
+++ b/src/pages/Research/index.tsx
@@ -187,7 +187,7 @@ const ResearchPage = () => {
         return;
       }
       setCreatingForTopicId(topicId);
-      const result = await dispatch(createProject(topicId));
+      const result = await dispatch(createProject({ topicId }));
       if (createProject.fulfilled.match(result) && result.payload) {
         navigate(`/app/project/${result.payload.id}`);
       } else if (createProject.rejected.match(result)) {

--- a/src/service/hooks.ts
+++ b/src/service/hooks.ts
@@ -31,12 +31,12 @@ class HooksService {
 
   async selectHook(
     hooksId: string,
-    hookIndex: number,
-    videoProjectId: string
+    hookIndex: number
   ): Promise<IBaseFetchResponse<SelectHookResponse>> {
+    // The owning project is resolved server-side from the stored hooks batch.
     const response = await baseFetch.post(
       this.urls.select.replace("{hooksId}", hooksId),
-      { hookIndex, videoProjectId }
+      { hookIndex }
     );
     return response.data;
   }

--- a/src/service/packaging.ts
+++ b/src/service/packaging.ts
@@ -134,10 +134,10 @@ class PackagingService {
     titles: ITitle[];
     selectedTitleIndex: number;
     description: string;
-    thumbnails: string[];
+    thumbnail: string[];
     selectedThumbnailIndex: number;
     hooks: string[];
-    shortsScripts: Array<{ id: string; segments: ITimestampedSegment[] }>;
+    shorts: { segments: ITimestampedSegment[]; totalDuration?: string };
   }): Promise<IBaseFetchResponse<SavePackagingResponse>> {
     const response = await baseFetch.post(this.urls.save, data);
     return response.data;

--- a/src/service/packaging.ts
+++ b/src/service/packaging.ts
@@ -36,13 +36,15 @@ class PackagingService {
     this.urls = URLS;
   }
 
+  // The selected hook is resolved server-side from the project's stored
+  // selection — pass `videoProjectId` (optional) instead of hook text.
   async generateTitle(
     script: string,
-    selectedHook?: string
+    videoProjectId?: string
   ): Promise<IBaseFetchResponse<GenerateTitleResponse>> {
     const response = await baseFetch.post(this.urls.generateTitle, {
       script,
-      ...(selectedHook !== undefined && { selectedHook }),
+      ...(videoProjectId !== undefined && { videoProjectId }),
     });
     return response.data;
   }
@@ -50,12 +52,12 @@ class PackagingService {
   async generateDescription(
     script: string,
     title: string,
-    selectedHook?: string
+    videoProjectId?: string
   ): Promise<IBaseFetchResponse<GenerateDescriptionResponse>> {
     const response = await baseFetch.post(this.urls.generateDescription, {
       script,
       title,
-      ...(selectedHook !== undefined && { selectedHook }),
+      ...(videoProjectId !== undefined && { videoProjectId }),
     });
     return response.data;
   }
@@ -63,12 +65,12 @@ class PackagingService {
   async generateThumbnail(
     script: string,
     title: string,
-    selectedHook?: string
+    videoProjectId?: string
   ): Promise<IBaseFetchResponse<GenerateThumbnailResponse>> {
     const response = await baseFetch.post(this.urls.generateThumbnail, {
       script,
       title,
-      ...(selectedHook !== undefined && { selectedHook }),
+      ...(videoProjectId !== undefined && { videoProjectId }),
     });
     return response.data;
   }
@@ -99,7 +101,7 @@ class PackagingService {
   async generateTitleDependentContent(
     script: string,
     duration: number = 60,
-    selectedHook?: string
+    videoProjectId?: string
   ): Promise<{
     title: GenerateTitleResponse;
     description: GenerateDescriptionResponse;
@@ -107,14 +109,14 @@ class PackagingService {
     shorts: GenerateShortsResponse;
   }> {
     // First, get titles (returns array of 3)
-    const titleResponse = await this.generateTitle(script, selectedHook);
+    const titleResponse = await this.generateTitle(script, videoProjectId);
     // Use the first title for dependent content generation
     const titleText = titleResponse?.data?.titles?.[0]?.title ?? "";
 
     // Then call description, thumbnail, and shorts in parallel with the title
     const [description, thumbnail, shorts] = await Promise.all([
-      this.generateDescription(script, titleText, selectedHook),
-      this.generateThumbnail(script, titleText, selectedHook),
+      this.generateDescription(script, titleText, videoProjectId),
+      this.generateThumbnail(script, titleText, videoProjectId),
       this.generateShorts(script, duration),
     ]);
 
@@ -162,7 +164,6 @@ class PackagingService {
       script: string;
       title?: string;
       duration?: number;
-      selectedHook?: string;
     }
   ): Promise<IBaseFetchResponse<RegenerateItemResponse>> {
     const response = await baseFetch.post(

--- a/src/service/script.ts
+++ b/src/service/script.ts
@@ -6,7 +6,7 @@ type FeedbackValue = "like" | "dislike" | null;
 
 const URLS = {
   scripts: "/v1/scripts",
-  streamScript: "/v1/scripts/stream/{scriptId}",
+  streamScript: "/v1/scripts/stream/{projectId}",
   scriptById: "/v1/scripts/{scriptId}",
   editScript: "/v1/scripts/edit/{scriptId}",
   feedback: "/v1/scripts/{scriptId}/feedback",
@@ -21,9 +21,11 @@ class ScriptService {
 
   // SSE via EventSource cannot send custom headers, so the Firebase token
   // is passed as a query parameter. This is the only endpoint that does this.
+  // Script generation is project-scoped: pass the video-project id; the server
+  // resolves the topic and links the generated script back to the project.
   startStreamingScripts = async (
-    id: string,
-    setter: (prev: string) => void,
+    projectId: string,
+    setter: (chunk: string) => void,
     onDone: () => void,
     onError: () => void
   ) => {
@@ -32,17 +34,24 @@ class ScriptService {
       throw new Error("Authentication token unavailable");
     }
 
-    const url = this.urls.streamScript.replace("{scriptId}", id);
+    const url = this.urls.streamScript.replace("{projectId}", projectId);
     const evtSource = new EventSource(
       getApiDomain(true) + url + `?token=${token}`
     );
 
     let consecutiveErrors = 0;
     evtSource.onmessage = (e) => {
+      // The stream terminates with a raw (non-JSON) sentinel frame.
+      if (e.data === "[DONE]") {
+        onDone();
+        evtSource.close();
+        return;
+      }
       try {
-        const script = JSON.parse(e.data);
+        // Each data frame is a JSON-encoded string chunk.
+        const chunk = JSON.parse(e.data) as string;
         consecutiveErrors = 0;
-        setter(script);
+        setter(chunk);
       } catch {
         consecutiveErrors++;
         if (consecutiveErrors >= 10) {
@@ -51,11 +60,6 @@ class ScriptService {
         }
       }
     };
-
-    evtSource.addEventListener("done", () => {
-      onDone();
-      evtSource.close();
-    });
 
     evtSource.onerror = () => {
       evtSource.close();

--- a/src/service/videoProject.ts
+++ b/src/service/videoProject.ts
@@ -44,11 +44,11 @@ class VideoProjectService {
 
   async updateWorkingTitle(
     projectId: string,
-    workingTitle: string
+    title: string
   ): Promise<IBaseFetchResponse<Partial<IVideoProjectListItem>>> {
     const response = await baseFetch.patch(
       this.urls.project.replace("{projectId}", projectId),
-      { workingTitle }
+      { title }
     );
     return response.data;
   }

--- a/src/service/videoProject.ts
+++ b/src/service/videoProject.ts
@@ -6,6 +6,7 @@ import {
   ListProjectsResponse,
   IVideoProjectListItem,
   ResourceType,
+  CreateProjectRequest,
 } from "@/types/feature/videoProject";
 
 const URLS = {
@@ -20,9 +21,9 @@ class VideoProjectService {
   private urls = URLS;
 
   async createProject(
-    topicId: string
+    payload: CreateProjectRequest
   ): Promise<IBaseFetchResponse<IVideoProject>> {
-    const response = await baseFetch.post(this.urls.projects, { topicId });
+    const response = await baseFetch.post(this.urls.projects, payload);
     return response.data;
   }
 

--- a/src/types/feature/packaging.ts
+++ b/src/types/feature/packaging.ts
@@ -51,20 +51,12 @@ export interface IDescriptionOutput {
   error: string | null;
 }
 
-export interface IShortsScript {
-  id: string;
+export interface IShortsOutput {
   segments: ITimestampedSegment[];
   totalDuration?: string;
   isLoading: boolean;
   error: string | null;
 }
-
-export interface IShortsOutput {
-  scripts: IShortsScript[];
-  isAddingNew: boolean;
-}
-
-export const MAX_SHORTS_SCRIPTS = 5;
 
 export interface IPackagingState {
   // Input
@@ -153,10 +145,10 @@ export interface SavePackagingRequest {
   titles: ITitle[];
   selectedTitleIndex: number;
   description: string;
-  thumbnails: string[];
+  thumbnail: string[];
   selectedThumbnailIndex: number;
   hooks: string[];
-  shortsScripts: Array<{ id: string; segments: ITimestampedSegment[] }>;
+  shorts: { segments: ITimestampedSegment[]; totalDuration?: string };
 }
 
 export interface SavePackagingResponse {
@@ -169,10 +161,10 @@ export interface GetPackagingResponse {
   titles: ITitle[];
   selectedTitleIndex: number;
   description: string;
-  thumbnails: string[];
+  thumbnail: string[];
   selectedThumbnailIndex: number;
   hooks: string[];
-  shortsScripts: Array<{ id: string; segments: ITimestampedSegment[] }>;
+  shorts: { segments: ITimestampedSegment[]; totalDuration?: string };
   createdAt: string;
   isStale: boolean;
   staleReason: "script_regenerated" | "hooks_regenerated" | null;

--- a/src/types/feature/videoProject.ts
+++ b/src/types/feature/videoProject.ts
@@ -66,9 +66,9 @@ export interface IStepTransitionResponse {
 }
 
 // API Request/Response Types
-export interface CreateProjectRequest {
-  topicId: string;
-}
+// Create a project from an existing topic candidate (`topicId`) OR from a
+// user-supplied idea (`title`) — exactly one, enforced server-side.
+export type CreateProjectRequest = { topicId: string } | { title: string };
 
 export interface ListProjectsParams {
   status?: OverallStatus;

--- a/src/types/feature/videoProject.ts
+++ b/src/types/feature/videoProject.ts
@@ -28,13 +28,13 @@ export interface IVideoProject {
   id: string;
   createdBy: string;
   title: string;
-  /**
-   * The ID of the topic this project was created from.
-   * The backend uses this as the script's deterministic ID — `scriptId === topicId`
-   * until a script is explicitly saved, at which point `scriptId` is set separately.
-   * Use `topicId` when calling script endpoints (stream, fetch, edit, export).
-   */
+  /** The ID of the topic this project was created from. */
   topicId: string;
+  /**
+   * The generated script's id — a UUID distinct from `topicId`, set once a
+   * script is generated. Use this (not `topicId`) for script fetch/edit/export/
+   * regenerate/feedback. Script streaming is keyed by the project id instead.
+   */
   scriptId: string | null;
   hooksId: string | null;
   selectedHookIndex: number | null;

--- a/src/types/feature/videoProject.ts
+++ b/src/types/feature/videoProject.ts
@@ -26,7 +26,8 @@ export interface IPipeline {
 
 export interface IVideoProject {
   id: string;
-  workingTitle: string;
+  createdBy: string;
+  title: string;
   /**
    * The ID of the topic this project was created from.
    * The backend uses this as the script's deterministic ID — `scriptId === topicId`
@@ -43,15 +44,15 @@ export interface IVideoProject {
   pipeline: IPipeline;
   isDeleted: boolean;
   createdAt: string;
-  lastUpdatedAt: string;
+  updatedAt: string;
 }
 
 export interface IVideoProjectListItem {
   id: string;
-  workingTitle: string;
+  title: string;
   currentStep: StepName;
   overallStatus: OverallStatus;
-  lastUpdatedAt: string;
+  updatedAt: string;
   createdAt: string;
   thumbnailHint: string | null;
 }
@@ -60,7 +61,7 @@ export interface IStepTransitionResponse {
   id: string;
   currentStep: StepName;
   pipeline: Partial<Record<StepName, IPipelineStep>>;
-  lastUpdatedAt: string;
+  updatedAt: string;
   overallStatus?: OverallStatus;
 }
 
@@ -82,7 +83,7 @@ export interface ListProjectsResponse {
 }
 
 export interface UpdateWorkingTitleRequest {
-  workingTitle: string;
+  title: string;
 }
 
 export interface LinkResourceRequest {

--- a/src/utils/feature/hooks/hooks.thunk.ts
+++ b/src/utils/feature/hooks/hooks.thunk.ts
@@ -31,16 +31,11 @@ export const selectHook = createAsyncThunk(
     {
       hooksId,
       hookIndex,
-      videoProjectId,
-    }: { hooksId: string; hookIndex: number; videoProjectId: string },
+    }: { hooksId: string; hookIndex: number },
     thunkAPI
   ) => {
     try {
-      const response = await hooksService.selectHook(
-        hooksId,
-        hookIndex,
-        videoProjectId
-      );
+      const response = await hooksService.selectHook(hooksId, hookIndex);
       handleToast({ message: response.message ?? '', warning: response.warning ?? '' });
       return response.data;
     } catch (error) {

--- a/src/utils/feature/packaging/packaging.slice.ts
+++ b/src/utils/feature/packaging/packaging.slice.ts
@@ -2,8 +2,6 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "@/utils/store";
 import {
   IPackagingState,
-  IShortsScript,
-  MAX_SHORTS_SCRIPTS,
   RegenerateItemResponse,
   GetPackagingResponse,
 } from "@/types/feature/packaging";
@@ -13,7 +11,6 @@ import {
   generateThumbnail,
   generateHooks,
   generateShorts,
-  addNewShortsScript,
   regenerateShortsScript,
   generateAllPackaging,
   generateAllPackagingForProject,
@@ -50,8 +47,10 @@ const initialState: IPackagingState = {
     error: null,
   },
   shortsScript: {
-    scripts: [],
-    isAddingNew: false,
+    segments: [],
+    totalDuration: undefined,
+    isLoading: false,
+    error: null,
   },
   isSaving: false,
   packagingId: null,
@@ -111,12 +110,6 @@ const packagingSlice = createSlice({
         (_, index) => index !== action.payload
       );
     },
-    // Shorts actions
-    deleteShortsScript: (state, action: PayloadAction<string>) => {
-      state.shortsScript.scripts = state.shortsScript.scripts.filter(
-        (s) => s.id !== action.payload
-      );
-    },
     hydrateFromResponse: (state, action: PayloadAction<GetPackagingResponse>) => {
       const data = action.payload;
       state.packagingId = data.id;
@@ -127,20 +120,17 @@ const packagingSlice = createSlice({
       state.description.content = data.description;
       state.description.isLoading = false;
       state.description.error = null;
-      state.thumbnails.descriptions = data.thumbnails;
+      state.thumbnails.descriptions = data.thumbnail;
       state.thumbnails.selectedIndex = data.selectedThumbnailIndex;
       state.thumbnails.isLoading = false;
       state.thumbnails.error = null;
       state.hooks.hooks = data.hooks;
       state.hooks.isLoading = false;
       state.hooks.error = null;
-      state.shortsScript.scripts = data.shortsScripts.map((s) => ({
-        id: s.id,
-        segments: s.segments,
-        isLoading: false,
-        error: null,
-      }));
-      state.shortsScript.isAddingNew = false;
+      state.shortsScript.segments = data.shorts?.segments ?? [];
+      state.shortsScript.totalDuration = data.shorts?.totalDuration;
+      state.shortsScript.isLoading = false;
+      state.shortsScript.error = null;
     },
     resetPackaging: () => initialState,
     clearErrors: (state) => {
@@ -149,9 +139,7 @@ const packagingSlice = createSlice({
       state.description.error = null;
       state.thumbnails.error = null;
       state.hooks.error = null;
-      state.shortsScript.scripts.forEach((s) => {
-        s.error = null;
-      });
+      state.shortsScript.error = null;
     },
   },
   extraReducers: (builder) => {
@@ -214,100 +202,36 @@ const packagingSlice = createSlice({
         state.hooks.error = (action.payload as string) ?? "Unknown error";
       })
 
-      // Generate Shorts
+      // Generate Shorts (single)
       .addCase(generateShorts.pending, (state) => {
-        const newScript: IShortsScript = {
-          id: `shorts_${Date.now()}`,
-          segments: [],
-          isLoading: true,
-          error: null,
-        };
-        state.shortsScript.scripts = [newScript];
+        state.shortsScript.segments = [];
+        state.shortsScript.totalDuration = undefined;
+        state.shortsScript.isLoading = true;
+        state.shortsScript.error = null;
       })
       .addCase(generateShorts.fulfilled, (state, action) => {
-        if (state.shortsScript.scripts.length > 0) {
-          state.shortsScript.scripts[0].isLoading = false;
-          state.shortsScript.scripts[0].segments =
-            action.payload?.segments || [];
-          if (action.payload?.totalDuration) {
-            state.shortsScript.scripts[0].totalDuration =
-              action.payload.totalDuration;
-          }
-        }
+        state.shortsScript.isLoading = false;
+        state.shortsScript.segments = action.payload?.segments ?? [];
+        state.shortsScript.totalDuration = action.payload?.totalDuration;
       })
       .addCase(generateShorts.rejected, (state, action) => {
-        if (state.shortsScript.scripts.length > 0) {
-          state.shortsScript.scripts[0].isLoading = false;
-          state.shortsScript.scripts[0].error = (action.payload as string) ?? "Unknown error";
-        }
+        state.shortsScript.isLoading = false;
+        state.shortsScript.error = (action.payload as string) ?? "Unknown error";
       })
 
-      // Add new shorts script
-      .addCase(addNewShortsScript.pending, (state) => {
-        state.shortsScript.isAddingNew = true;
-        const newScript: IShortsScript = {
-          id: `shorts_${Date.now()}`,
-          segments: [],
-          isLoading: true,
-          error: null,
-        };
-        state.shortsScript.scripts.push(newScript);
-      })
-      .addCase(addNewShortsScript.fulfilled, (state, action) => {
-        state.shortsScript.isAddingNew = false;
-        const lastScript =
-          state.shortsScript.scripts[state.shortsScript.scripts.length - 1];
-        if (lastScript) {
-          lastScript.isLoading = false;
-          lastScript.segments = action.payload?.segments || [];
-          if (action.payload?.totalDuration) {
-            lastScript.totalDuration = action.payload.totalDuration;
-          }
-        }
-      })
-      .addCase(addNewShortsScript.rejected, (state, action) => {
-        state.shortsScript.isAddingNew = false;
-        const lastScript =
-          state.shortsScript.scripts[state.shortsScript.scripts.length - 1];
-        if (lastScript) {
-          lastScript.isLoading = false;
-          lastScript.error = (action.payload as string) ?? "Unknown error";
-        }
-      })
-
-      // Regenerate specific shorts script
-      .addCase(regenerateShortsScript.pending, (state, action) => {
-        const scriptId = action.meta.arg;
-        const script = state.shortsScript.scripts.find(
-          (s) => s.id === scriptId
-        );
-        if (script) {
-          script.isLoading = true;
-          script.error = null;
-        }
+      // Regenerate single shorts script
+      .addCase(regenerateShortsScript.pending, (state) => {
+        state.shortsScript.isLoading = true;
+        state.shortsScript.error = null;
       })
       .addCase(regenerateShortsScript.fulfilled, (state, action) => {
-        const { id, segments, totalDuration } = action.payload;
-        const script = state.shortsScript.scripts.find((s) => s.id === id);
-        if (script) {
-          script.isLoading = false;
-          if (segments) {
-            script.segments = segments;
-          }
-          if (totalDuration) {
-            script.totalDuration = totalDuration;
-          }
-        }
+        state.shortsScript.isLoading = false;
+        state.shortsScript.segments = action.payload?.segments ?? [];
+        state.shortsScript.totalDuration = action.payload?.totalDuration;
       })
       .addCase(regenerateShortsScript.rejected, (state, action) => {
-        const scriptId = action.meta.arg;
-        const script = state.shortsScript.scripts.find(
-          (s) => s.id === scriptId
-        );
-        if (script) {
-          script.isLoading = false;
-          script.error = (action.payload as string) ?? "Unknown error";
-        }
+        state.shortsScript.isLoading = false;
+        state.shortsScript.error = (action.payload as string) ?? "Unknown error";
       })
 
       // Generate All
@@ -321,13 +245,10 @@ const packagingSlice = createSlice({
         state.thumbnails.error = null;
         state.hooks.isLoading = true;
         state.hooks.error = null;
-        const newScript: IShortsScript = {
-          id: `shorts_${Date.now()}`,
-          segments: [],
-          isLoading: true,
-          error: null,
-        };
-        state.shortsScript.scripts = [newScript];
+        state.shortsScript.segments = [];
+        state.shortsScript.totalDuration = undefined;
+        state.shortsScript.isLoading = true;
+        state.shortsScript.error = null;
       })
       .addCase(generateAllPackaging.fulfilled, (state, action) => {
         state.isGeneratingAll = false;
@@ -347,16 +268,10 @@ const packagingSlice = createSlice({
         // Update hooks
         state.hooks.isLoading = false;
         state.hooks.hooks = action.payload.hooks?.hooks || [];
-        // Update shorts
-        if (state.shortsScript.scripts.length > 0) {
-          state.shortsScript.scripts[0].isLoading = false;
-          state.shortsScript.scripts[0].segments =
-            action.payload.shorts.segments || [];
-          if (action.payload.shorts.totalDuration) {
-            state.shortsScript.scripts[0].totalDuration =
-              action.payload.shorts.totalDuration;
-          }
-        }
+        // Update shorts (single object)
+        state.shortsScript.isLoading = false;
+        state.shortsScript.segments = action.payload.shorts.segments || [];
+        state.shortsScript.totalDuration = action.payload.shorts.totalDuration;
       })
       .addCase(generateAllPackaging.rejected, (state, action) => {
         state.isGeneratingAll = false;
@@ -364,9 +279,7 @@ const packagingSlice = createSlice({
         state.description.isLoading = false;
         state.thumbnails.isLoading = false;
         state.hooks.isLoading = false;
-        if (state.shortsScript.scripts.length > 0) {
-          state.shortsScript.scripts[0].isLoading = false;
-        }
+        state.shortsScript.isLoading = false;
         state.error = (action.payload as string) ?? "Unknown error";
       })
 
@@ -379,13 +292,10 @@ const packagingSlice = createSlice({
         state.description.error = null;
         state.thumbnails.isLoading = true;
         state.thumbnails.error = null;
-        const newScript: IShortsScript = {
-          id: `shorts_${Date.now()}`,
-          segments: [],
-          isLoading: true,
-          error: null,
-        };
-        state.shortsScript.scripts = [newScript];
+        state.shortsScript.segments = [];
+        state.shortsScript.totalDuration = undefined;
+        state.shortsScript.isLoading = true;
+        state.shortsScript.error = null;
       })
       .addCase(generateAllPackagingForProject.fulfilled, (state, action) => {
         state.isGeneratingAll = false;
@@ -397,22 +307,16 @@ const packagingSlice = createSlice({
         state.thumbnails.isLoading = false;
         state.thumbnails.descriptions = action.payload.thumbnail.descriptions || [];
         state.thumbnails.selectedIndex = 0;
-        if (state.shortsScript.scripts.length > 0) {
-          state.shortsScript.scripts[0].isLoading = false;
-          state.shortsScript.scripts[0].segments = action.payload.shorts.segments || [];
-          if (action.payload.shorts.totalDuration) {
-            state.shortsScript.scripts[0].totalDuration = action.payload.shorts.totalDuration;
-          }
-        }
+        state.shortsScript.isLoading = false;
+        state.shortsScript.segments = action.payload.shorts.segments || [];
+        state.shortsScript.totalDuration = action.payload.shorts.totalDuration;
       })
       .addCase(generateAllPackagingForProject.rejected, (state, action) => {
         state.isGeneratingAll = false;
         state.titles.isLoading = false;
         state.description.isLoading = false;
         state.thumbnails.isLoading = false;
-        if (state.shortsScript.scripts.length > 0) {
-          state.shortsScript.scripts[0].isLoading = false;
-        }
+        state.shortsScript.isLoading = false;
         state.error = (action.payload as string) ?? "Unknown error";
       })
 
@@ -488,11 +392,11 @@ const packagingSlice = createSlice({
             break;
           }
           case "shorts": {
-            if (payload.data.segments && state.shortsScript.scripts.length > 0) {
-              state.shortsScript.scripts[0].segments = payload.data.segments;
-              if (payload.data.totalDuration) {
-                state.shortsScript.scripts[0].totalDuration = payload.data.totalDuration;
-              }
+            if (payload.data.segments) {
+              state.shortsScript.segments = payload.data.segments;
+            }
+            if (payload.data.totalDuration) {
+              state.shortsScript.totalDuration = payload.data.totalDuration;
             }
             break;
           }
@@ -544,7 +448,6 @@ export const {
   setSelectedThumbnail,
   updateHook,
   deleteHook,
-  deleteShortsScript,
   hydrateFromResponse,
   resetPackaging,
   clearErrors,
@@ -561,8 +464,6 @@ export const selectThumbnails = (state: RootState) =>
 export const selectHooks = (state: RootState) => state.packaging.hooks;
 export const selectShortsScripts = (state: RootState) =>
   state.packaging.shortsScript;
-export const selectCanAddMoreShorts = (state: RootState) =>
-  state.packaging.shortsScript.scripts.length < MAX_SHORTS_SCRIPTS;
 export const selectIsSaving = (state: RootState) => state.packaging.isSaving;
 export const selectIsGeneratingAll = (state: RootState) =>
   state.packaging.isGeneratingAll;
@@ -590,6 +491,6 @@ export const selectHasContent = (state: RootState) =>
   !!state.packaging.description.content ||
   state.packaging.thumbnails.descriptions.length > 0 ||
   state.packaging.hooks.hooks.length > 0 ||
-  state.packaging.shortsScript.scripts.length > 0;
+  state.packaging.shortsScript.segments.length > 0;
 
 export default packagingSlice.reducer;

--- a/src/utils/feature/packaging/packaging.thunk.ts
+++ b/src/utils/feature/packaging/packaging.thunk.ts
@@ -87,34 +87,15 @@ export const generateShorts = createAsyncThunk(
   }
 );
 
-// Add a new shorts script (up to 5 total)
-export const addNewShortsScript = createAsyncThunk(
-  "packaging/addNewShortsScript",
+// Regenerate the single shorts script
+export const regenerateShortsScript = createAsyncThunk(
+  "packaging/regenerateShortsScript",
   async (_, thunkAPI) => {
     try {
       const state = thunkAPI.getState() as RootState;
       const { script } = state.packaging;
       const response = await packagingService.generateShorts(script);
       return response.data;
-    } catch (error) {
-      return thunkAPI.rejectWithValue(getErrorMessage(error));
-    }
-  }
-);
-
-// Regenerate a specific shorts script by ID
-export const regenerateShortsScript = createAsyncThunk(
-  "packaging/regenerateShortsScript",
-  async (scriptId: string, thunkAPI) => {
-    try {
-      const state = thunkAPI.getState() as RootState;
-      const { script } = state.packaging;
-      const response = await packagingService.generateShorts(script);
-      return {
-        id: scriptId,
-        segments: response.data?.segments,
-        totalDuration: response.data?.totalDuration,
-      };
     } catch (error) {
       return thunkAPI.rejectWithValue(getErrorMessage(error));
     }
@@ -187,13 +168,13 @@ export const savePackaging = createAsyncThunk(
         titles: titles.titles,
         selectedTitleIndex: titles.selectedIndex,
         description: description.content,
-        thumbnails: thumbnails.descriptions,
+        thumbnail: thumbnails.descriptions,
         selectedThumbnailIndex: thumbnails.selectedIndex,
         hooks: hooks.hooks,
-        shortsScripts: shortsScript.scripts.map((s) => ({
-          id: s.id,
-          segments: s.segments,
-        })),
+        shorts: {
+          segments: shortsScript.segments,
+          totalDuration: shortsScript.totalDuration,
+        },
       });
       handleToast({ message: response.message ?? "", warning: response.warning ?? "" });
       return response.data;

--- a/src/utils/feature/packaging/packaging.thunk.ts
+++ b/src/utils/feature/packaging/packaging.thunk.ts
@@ -152,14 +152,14 @@ export const generateAllPackaging = createAsyncThunk(
 export const generateAllPackagingForProject = createAsyncThunk(
   "packaging/generateAllForProject",
   async (
-    { script, selectedHook }: { script: string; selectedHook?: string },
+    { script, videoProjectId }: { script: string; videoProjectId?: string },
     thunkAPI
   ) => {
     try {
       const result = await packagingService.generateTitleDependentContent(
         script,
         60,
-        selectedHook
+        videoProjectId
       );
       return {
         title: result.title,
@@ -235,17 +235,18 @@ export const regenerateItem = createAsyncThunk<
     script: string;
     title?: string;
     duration?: number;
-    selectedHook?: string;
   }
 >(
   "packaging/regenerateItem",
   async (arg, thunkAPI) => {
     try {
-      const { packagingId, item, script, title, duration, selectedHook } = arg;
+      const { packagingId, item, script, title, duration } = arg;
+      // The hook is resolved server-side from the videoProjectId stored on the
+      // packaging document — nothing hook-related is sent from the client.
       const response = await packagingService.regenerateItem(
         packagingId,
         item,
-        { script, title, duration, selectedHook }
+        { script, title, duration }
       );
       handleToast({ message: response.message ?? "", warning: response.warning ?? "" });
       if (!response.data) {

--- a/src/utils/feature/videoProject/videoProject.slice.ts
+++ b/src/utils/feature/videoProject/videoProject.slice.ts
@@ -52,10 +52,10 @@ const videoProjectSlice = createSlice({
         if (action.payload) {
           state.projects.unshift({
             id: action.payload.id,
-            workingTitle: action.payload.workingTitle,
+            title: action.payload.title,
             currentStep: action.payload.currentStep,
             overallStatus: action.payload.overallStatus,
-            lastUpdatedAt: action.payload.lastUpdatedAt,
+            updatedAt: action.payload.updatedAt,
             createdAt: action.payload.createdAt,
             thumbnailHint: null,
           });
@@ -113,13 +113,13 @@ const videoProjectSlice = createSlice({
       .addCase(updateWorkingTitle.fulfilled, (state, action) => {
         state.isUpdating = false;
         const { projectId } = action.meta.arg;
-        const newTitle = action.payload?.workingTitle ?? action.meta.arg.workingTitle;
+        const newTitle = action.payload?.title ?? action.meta.arg.title;
         const project = state.projects.find((p) => p.id === projectId);
         if (project) {
-          project.workingTitle = newTitle;
+          project.title = newTitle;
         }
         if (state.currentProject?.id === projectId) {
-          state.currentProject.workingTitle = newTitle;
+          state.currentProject.title = newTitle;
         }
       })
       .addCase(updateWorkingTitle.rejected, (state, action) => {
@@ -155,7 +155,7 @@ const videoProjectSlice = createSlice({
         state.isStepTransitioning = false;
         if (state.currentProject && action.payload) {
           state.currentProject.currentStep = action.payload.currentStep;
-          state.currentProject.lastUpdatedAt = action.payload.lastUpdatedAt;
+          state.currentProject.updatedAt = action.payload.updatedAt;
           if (action.payload.overallStatus) {
             state.currentProject.overallStatus = action.payload.overallStatus;
           }
@@ -181,7 +181,7 @@ const videoProjectSlice = createSlice({
         state.isStepTransitioning = false;
         if (state.currentProject && action.payload) {
           state.currentProject.currentStep = action.payload.currentStep;
-          state.currentProject.lastUpdatedAt = action.payload.lastUpdatedAt;
+          state.currentProject.updatedAt = action.payload.updatedAt;
           if (action.payload.overallStatus) {
             state.currentProject.overallStatus = action.payload.overallStatus;
           }
@@ -226,11 +226,11 @@ const videoProjectSlice = createSlice({
           if (payload.overallStatus !== undefined) {
             state.currentProject.overallStatus = payload.overallStatus;
           }
-          if (payload.workingTitle !== undefined) {
-            state.currentProject.workingTitle = payload.workingTitle;
+          if (payload.title !== undefined) {
+            state.currentProject.title = payload.title;
           }
-          if (payload.lastUpdatedAt !== undefined) {
-            state.currentProject.lastUpdatedAt = payload.lastUpdatedAt;
+          if (payload.updatedAt !== undefined) {
+            state.currentProject.updatedAt = payload.updatedAt;
           }
           // Deep merge pipeline steps if present
           if (payload.pipeline) {

--- a/src/utils/feature/videoProject/videoProject.thunk.ts
+++ b/src/utils/feature/videoProject/videoProject.thunk.ts
@@ -56,13 +56,13 @@ export const getProject = createAsyncThunk(
 export const updateWorkingTitle = createAsyncThunk(
   "videoProject/updateTitle",
   async (
-    { projectId, workingTitle }: { projectId: string; workingTitle: string },
+    { projectId, title }: { projectId: string; title: string },
     thunkAPI
   ) => {
     try {
       const response = await videoProjectService.updateWorkingTitle(
         projectId,
-        workingTitle
+        title
       );
       handleToast({ message: response.message ?? "", warning: response.warning ?? "" });
       return response.data;

--- a/src/utils/feature/videoProject/videoProject.thunk.ts
+++ b/src/utils/feature/videoProject/videoProject.thunk.ts
@@ -5,6 +5,7 @@ import {
   ListProjectsParams,
   ResourceType,
   StepName,
+  CreateProjectRequest,
 } from "@/types/feature/videoProject";
 
 const getErrorMessage = (error: unknown): string =>
@@ -12,9 +13,9 @@ const getErrorMessage = (error: unknown): string =>
 
 export const createProject = createAsyncThunk(
   "videoProject/create",
-  async (topicId: string, thunkAPI) => {
+  async (payload: CreateProjectRequest, thunkAPI) => {
     try {
-      const response = await videoProjectService.createProject(topicId);
+      const response = await videoProjectService.createProject(payload);
       handleToast({ message: response.message ?? "", warning: response.warning ?? "" });
       return response.data;
     } catch (error) {

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,12 +1,11 @@
 import axios from "axios";
 import { getAuth } from "firebase/auth";
 export const getApiDomain = (isLongResponse = false) => {
-  if (isLongResponse) return "https://momentumx-be.onrender.com";
   const env = import.meta.env.VITE_ENV || "production";
+  if (env === "local") return "http://localhost:3000";
+  if (isLongResponse) return "https://momentumx-be.onrender.com";
   switch (env) {
     case "dev":
-      return "https://momentumx-be.vercel.app";
-    case "local":
     default: // in future add prod in default
       return "https://momentumx-be.vercel.app";
   }


### PR DESCRIPTION
## Summary

Adapts the frontend to the backend contract changes captured in the handoff log, plus dashboard loop/auth fixes. Every change was verified against the backend source (not just the doc).

## Commits

| Cluster | Change |
|---|---|
| Routing/auth | Resolve dashboard request loop and broken auth redirects |
| A | Field renames `workingTitle`→`title`, `lastUpdatedAt`→`updatedAt`, `+createdBy`; update sends `{ title }` |
| C′ #4, #9 | Hook resolved server-side — `hooks/select` sends only `{ hookIndex }`; packaging generate sends optional `videoProjectId`; regenerate sends nothing hook-related |
| C′ #1, #2 | Project-scoped script streaming (`:projectId`, JSON chunks, `[DONE]` sentinel); read script id from `project.scriptId` (UUID), not `topicId` |
| C′ #3 | `createProject` accepts `{ topicId }` or `{ title }` |
| C′ #7 | Packaging save/load aligned to canonical `thumbnail`/`shorts` keys; multi-shorts collapsed to a single shorts script (backend persists only one) |

## Already compliant (verified, no change needed)

- **B1 / C′ #8** — `stale` rendering, status filter, and `thumbnailHint` truncation already present.
- **D1–D4** — no trending `400` handling to remove; archived filter is legacy-only & harmless; hooks-regen "needs re-selection" already correct; re-save doesn't assume stale clears.
- **Security/errors** — edits already send only whitelisted fields; nothing reads an error `detail`; SSE failures handled generically.

## Notable

- **C′ #7 was actually broken**, not cosmetic: the FE sent `thumbnails`/`shortsScripts` (unrecognized by the backend), so thumbnail/shorts silently failed to save/load. Now fixed. Multi-shorts was collapsed to single-shorts since the backend persists only one.

## Follow-ups (out of scope — product features)

- **C′ #3** — UI form for "write my own idea" (capability is wired; no input form yet).
- **C′ #5** — rename-on-create + dashboard differentiator for multiple projects from the same topic.
- Multi-shorts would require a backend change first.

All commits build clean (`npm run build`) and lint clean.